### PR TITLE
Update LicenseChecker.java on Android 5 intent error

### DIFF
--- a/src/com/google/android/vending/licensing/LicenseChecker.java
+++ b/src/com/google/android/vending/licensing/LicenseChecker.java
@@ -148,14 +148,17 @@ public class LicenseChecker implements ServiceConnection {
             if (mService == null) {
                 Log.i(TAG, "Binding to licensing service.");
                 try {
-                    boolean bindResult = mContext
-                            .bindService(
-                                    new Intent(
-                                            new String(
-                                                    Base64.decode("Y29tLmFuZHJvaWQudmVuZGluZy5saWNlbnNpbmcuSUxpY2Vuc2luZ1NlcnZpY2U="))),
-                                    this, // ServiceConnection.
-                                    Context.BIND_AUTO_CREATE);
+                    Intent serviceIntent = new Intent(
+						new String(Base64.decode("Y29tLmFuZHJvaWQudmVuZGluZy5saWNlbnNpbmcuSUxpY2Vuc2luZ1NlcnZpY2U=")));
+					serviceIntent.setPackage("com.android.vending");
 
+					boolean bindResult = mContext
+						.bindService(
+						serviceIntent,
+						this, // ServiceConnection.
+						Context.BIND_AUTO_CREATE
+					);
+					
                     if (bindResult) {
                         mPendingChecks.offer(validator);
                     } else {


### PR DESCRIPTION
Thanks to 
http://stackoverflow.com/questions/26530565/android-5-0-l-service-intent-must-be-explicit-in-google-analytics
